### PR TITLE
fix typo, add include to cells helpers docs

### DIFF
--- a/gems/cells/helpers.md
+++ b/gems/cells/helpers.md
@@ -12,9 +12,10 @@ Conceptually, Cells doesn't have helpers anymore. You can still include modules 
 You can use the `#t` helper.
 
 
-	require "cell/translation"
+	require "cells/translation"
 
 	class Admin::Comment::Cell < Cell::Concept
+	  include ActionView::Helpers::TranslationHelper
 	  include Cell::Translation
 
 	  def show


### PR DESCRIPTION
`Cell::Translation` must be required via `cells/translation`
One must also include `include ActionView::Helpers::TranslationHelper`

Also of note: this only works on the latest `cells` master, not yet released
