### PR TITLE
Fix indentation typo in reform index page

### DIFF
--- a/gems/reform/index.md
+++ b/gems/reform/index.md
@@ -39,10 +39,10 @@ In addition to the main API, forms expose accessors to the defined properties. T
 In your controller or operation you create a form instance and pass in the models you want to work on.
 
 
-  class AlbumsController
-    def new
-      @form = AlbumForm.new(Album.new)
-    end
+    class AlbumsController
+      def new
+        @form = AlbumForm.new(Album.new)
+      end
 
 
 This will also work as an editing form with an existing album.


### PR DESCRIPTION
These lines on the website were not showing as code, fixed indentation.

![image](https://cloud.githubusercontent.com/assets/498234/12218406/4b753d18-b6ec-11e5-80db-331888b32275.png)

![image](https://cloud.githubusercontent.com/assets/498234/12218421/b642f05e-b6ec-11e5-9ac2-e98905f0f8dd.png)
