### PR TITLE
Minor corrections to Operation Controller methods documentation

### DIFF
--- a/gems/operation/controller.md
+++ b/gems/operation/controller.md
@@ -40,7 +40,7 @@ Use `#run` to invoke the operation.
       end
     end
 
-This _runs_ the operation with `params`, sets `@operation` and `@model` on the controller instance, and returns the operation instance.
+This _runs_ the operation with `params`, sets `@operation`, `@model` and `@form` on the controller instance, and returns the operation instance.
 
 Note that you can grab the operation and reassign it to another instance variable if you have multiple operation invocations.
 
@@ -57,6 +57,7 @@ The call stack in `#run` is as follows.
       result, op = Comment::Create.run(params)
       @operation = op
       @model     = op.model
+      @form      = op.contract
 
 First, you have the chance to normalize parameters. The controller's `params` hash is then passed into the operation run. After that, operation and model are assigned to controller instance variables.
 

--- a/gems/operation/controller.md
+++ b/gems/operation/controller.md
@@ -113,7 +113,7 @@ Note that no `@form` is instantiated and assigned to the controller. If you need
 To render the operation's form, use `#form`. This is identical to `#present` with two additional steps.
 
     class CommentsController < ApplicationController
-      def show
+      def new
         form Comment::Create
       end
     end


### PR DESCRIPTION
The controller helper method `run` also sets @form to the operations contract. This was missing from the documentation.

The documentation for the form method was using the controller method 'show', but it should be 'new'
