### PR TITLE
Change Policy to Trailblazer::Operation::Policy

### DIFF
--- a/gems/operation/policy.md
+++ b/gems/operation/policy.md
@@ -34,11 +34,11 @@ This class would probably be best located at `app/concepts/thing/policy.rb`.
 
 ## Operation Policy
 
-Use `::policy` to hook the policy class along with a query action into your operation.
+Use `Trailblazer::Operation::Policy` to hook the policy class along with a query action into your operation.
 
 
     class Thing::Create < Trailblazer::Operation
-      include Policy
+      include Trailblazer::Operation::Policy
 
       policy Thing::Policy, :create?
 
@@ -73,7 +73,8 @@ Pundit policy classes can be used directly in operations.
 
 
     class Thing::Create < Trailblazer::Operation
-      include Policy
+      include Trailblazer::Operation::Policy
+
       policy ThingPolicy, :create?
 
 


### PR DESCRIPTION
The documentation recommends creating a policy file per concept (e.g. Thing::Policy), but then goes on to demonstrate using this as:

  include Policy
  policy Thing::Policy, create?

This will fail, as the first include will resolve to Thing::Policy and not Trailblazer::Operation::Policy.
