### PR TITLE
Change some misleading #process examples

### DIFF
--- a/gems/operation/api.md
+++ b/gems/operation/api.md
@@ -117,7 +117,7 @@ The `validate` method will instantiate the operation's Reform form with the mode
       def process(params)
         manual_model = Comment.find(1)
 
-        validate(params, manual_model) do
+        validate(params[:comment], manual_model) do
           contract.save
         end
       end
@@ -138,7 +138,7 @@ However, since most operations use `Model`, we can omit a lot of code here.
       end
 
       def process(params)
-        validate(params) do
+        validate(params[:comment]) do
           contract.save
         end
       end

--- a/index.md
+++ b/index.md
@@ -107,7 +107,7 @@ description: "Trailblazer introduces additional abstraction layers into Ruby fra
     end
 
     def process(params)
-      if validate(params)
+      if validate(params[:comment])
 
       else
 


### PR DESCRIPTION
Normal Rails-y forms put attributes for a Comment in `params[:comment]`. The Operation gets all of the params, but the contract should only the subset of params for its model.
