### PR TITLE
Fix multiple broken links on the trailblazer site

### DIFF
--- a/gems/cells/rails.md
+++ b/gems/cells/rails.md
@@ -81,7 +81,7 @@ You still need to `require` the JS and CSS files. Here's an example for `app/ass
 
 ## Assets Troubleshooting
 
-The Asset Pipeline is a complex system. If your assets are not compiled, start debugging in [Cells' railtie](https://github.com/apotonick/cells/blob/master/lib/cell/railtie.rb) and uncomment the `puts` in the `cells.update_asset_paths` initializer to see what directories get added.
+The Asset Pipeline is a complex system. If your assets are not compiled, start debugging in [Cells' railtie](https://github.com/trailblazer/cells-rails/blob/master/lib/cell/railtie.rb) and uncomment the `puts` in the `cells.update_asset_paths` initializer to see what directories get added.
 
 Cell classes need to be loaded when precompiling assets! Make sure your `application.rb` contains the following setting (per default, this is turned _on_).
 

--- a/gems/representable/3.0/api.md
+++ b/gems/representable/3.0/api.md
@@ -465,7 +465,7 @@ end
 
 Coercing values only happens when rendering or parsing a document. Representable does not create accessors in your model as `virtus` does.
 
-Note that we think coercion in the representer is wrong, and should happen on the underlying object. We have a rich [coercion/constraint API for twins](/gems/disposable/coercion.html).
+Note that we think coercion in the representer is wrong, and should happen on the underlying object. We have a rich [coercion/constraint API for twins](disposable/api.html#coercion).
 
 
 ## Symbol Keys

--- a/index.md
+++ b/index.md
@@ -440,7 +440,7 @@ description: "Trailblazer introduces additional abstraction layers into Ruby fra
 
           <p>In the book, <b>we build a realistic Rails application with Trailblazer</b> that discusses convoluted requirements such as dynamic forms, polymorphic rendering and processing for signed-in users, file uploads, pagination, a JSON document API sitting on top of that, and many more problems you run into when building web applications.</p>
 
-          <p>Check out the <a href="/books/trailblazer.html">full book description</a> for a few more details about the content.</p>
+          <p>Check out the <a href="https://leanpub.com/trailblazer">full book description</a> for a few more details about the content.</p>
 
           <p>If you want to learn about this project and if you feel like supporting Open-Source, please <a href="https://leanpub.com/trailblazer">buy and read it</a> and let us know what you think.</p>
           <a href="https://leanpub.com/trailblazer" class="button radius">Buy Book</a>
@@ -651,4 +651,3 @@ description: "Trailblazer introduces additional abstraction layers into Ruby fra
     </div>
   </div>
 </section>
-

--- a/newsletter/2016-january.md
+++ b/newsletter/2016-january.md
@@ -16,7 +16,7 @@ This is newsletter no. 1, the first ever, and I'm excited to tell you what has h
 
 ### Formular - A New Form Builder for Ruby
 
-One of the coolest projects we've been working on the last weeks is the [Formular gem](https://github.com/apotonick/formular), a new form rendering gem like SimpleForm, but, as opposed to many other form builders out there, completely framework-agnostic.
+One of the coolest projects we've been working on the last weeks is the [Formular gem](https://github.com/trailblazer/formular), a new form rendering gem like SimpleForm, but, as opposed to many other form builders out there, completely framework-agnostic.
 
 Formular is built without using any outdated Rails helpers, making it insanely fast and usable in many frameworks, namely Rails, Hanami, or Sinatra. Its API is following the best practices established by existing form builders, without inheriting all the problems originating from strong coupling.
 
@@ -30,7 +30,7 @@ Formular is built without using any outdated Rails helpers, making it insanely f
     = f.radio :owner, label: "Konsti", value: 2
 ```
 
-It ships with extensions for Foundation 5 and Bootstrap 3. Again, the implementational approach here is different. Instead of configuring, Formular gets extended [with plain Ruby classes](https://github.com/apotonick/formular/blob/210461c543c63634ddeb69b2db9c326cd0c920da/lib/formular/frontend/bootstrap3.rb). It is incredibly simple to add new frontends or extend existing behavior.
+It ships with extensions for Foundation 5 and Bootstrap 3. Again, the implementational approach here is different. Instead of configuring, Formular gets extended [with plain Ruby classes](https://github.com/trailblazer/formular/blob/210461c543c63634ddeb69b2db9c326cd0c920da/lib/formular/frontend/bootstrap3.rb). It is incredibly simple to add new frontends or extend existing behavior.
 
 Formular will be released soon after a beta-test phase. Please contact us on our [Gitter channel](http://gitter.im/trailblazer/chat) if you're interested in giving Formular a go!
 
@@ -155,13 +155,13 @@ A very helpful new addition that many users have asked for. Well, here it is!
 
 ## Trailblazer Book and Trailblazer Primer
 
-The [Trailblazer book](http://trailblazer.to/books/trailblazer) was published a few months ago, without any noteable marketing it has already attracted more than 600 readers. If you don't have it yet, [grab it now and get a $10 discount](http://leanpub.com/trailblazer/c/EPIgtwW2WG0z) until Feb 4!
+The [Trailblazer book](https://leanpub.com/trailblazer) was published a few months ago, without any noteable marketing it has already attracted more than 600 readers. If you don't have it yet, [grab it now and get a $10 discount](http://leanpub.com/trailblazer/c/EPIgtwW2WG0z) until Feb 4!
 
 It will teach you everything about engineering complex Rails applications with Trailblazer from authorization, validations, operations and persistence to hypermedia API parsing and rendering.
 
 While this book focuses on a Rails scenario, it can easily be adapted to other frameworks.
 
-Many future users have asked for a "quicker, more compressed" way to see Trailblazer in action. While they appreciate the details of discussion in the Trailblazer book, most users want to start programming and learn about it later, which is why I will soon start writing the [Trailblazer Primer](http://trailblazer.to/books/trailblazer-primer), a very brief HOWTO about adding Trailblazer to existing applications without in-depth explanations.
+Many future users have asked for a "quicker, more compressed" way to see Trailblazer in action. While they appreciate the details of discussion in the Trailblazer book, most users want to start programming and learn about it later, which is why I will soon start writing the [Trailblazer Primer](https://leanpub.com/trailblazer-primer), a very brief HOWTO about adding Trailblazer to existing applications without in-depth explanations.
 
 ## Cells and Hamlit
 


### PR DESCRIPTION
This commit fixes multiple broken links on the trailblazer site.

In the process I also discovered the following broken links but was unsure where you might want them pointed or if they should be deleted:
- [Link to pipeline in representable/3.0/function_api](https://github.com/trailblazer/trailblazer.github.io/blob/f6/gems/representable/3.0/function-api.md#function-api)
- [Link to hire you in representable/3.0/xml](https://github.com/trailblazer/trailblazer.github.io/blob/f6/gems/representable/3.0/xml.md#development-status)
- [Link to gemgem to demonstrate auto-including Model::ActiveModel for all CRUD operations in operation/api](https://github.com/trailblazer/trailblazer.github.io/blob/f6/gems/operation/api.md#activemodel-semantics)

Hope this is helpful, thanks for all the work on trailblazer.
