### PR TITLE
Reform callable populators are passed as instances

### DIFF
--- a/gems/reform/populator.html
+++ b/gems/reform/populator.html
@@ -224,7 +224,7 @@ end
   end
 end
 
-property :artist, populator: ArtistPopulator
+property :artist, populator: ArtistPopulator.new
 </code></pre>
 </div>
 


### PR DESCRIPTION
Correctly show that `Callable` populators are passed as instances.