### PR TITLE
Include example of how to skip from callable populator

### DIFF
--- a/gems/reform/populator.html
+++ b/gems/reform/populator.html
@@ -487,6 +487,20 @@ end
 </code></pre>
 </div>
 
+<p>To skip from a <code class="highlighter-rouge">Uber::Callable</code>-marked object, return <code class="highlighter-rouge">Representable::Pipeline::Stop</code>.
+
+<div class="highlighter-rouge">
+<pre class="highlight"><code>class SongsPopulator
+  def call(options)
+    return Representable::Pipeline::Stop if fragment["id"]
+    # ...
+  end
+end
+
+collection :songs, populator: SongsPopulator.new
+</code></pre>
+</div>
+
 <p>This won’t process items that have an <code class="highlighter-rouge">"id"</code> field in their corresponding fragment.</p>
 
 <h2 id="uninitialized-collections" data-magellan-target="uninitialized-collections">Uninitialized Collections</h2>


### PR DESCRIPTION
Currently there is no nice way to `skip!` inside of a callable populator. So for now show how it can be done by returning `Representable::Pipeline::Stop`. Maybe Reform could provide a module that users could include that would automatically include `Uber::Callable`, and also implement a `skip!` method?