### PR TITLE
Hide side nav sub-links that aren't related to the 'active' page

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,101 +1,122 @@
-<ul class="vertical menu side-nav">
-    <li class="heading">
-        <a href="/gems/operation/2.0/index.html">
+<ul class="vertical menu side-nav" data-accordion-menu>
+    <li>
+        <a class="heading" href="#">
             <i class="fa fa-caret-square-o-right" aria-hidden="true"></i> OPERATION
         </a>
+        <ul class='menu vertical nested'>
+            <li><a href="/gems/operation/2.0/index.html">Overview</a></li>
+            <li><a href="/gems/operation/2.0/api.html">API</a></li>
+            <li><a href="/gems/operation/2.0/contract.html">Contract</a></li>
+            <!-- <li><a href="/gems/operation/2.0/representer.html">Representer</a></li> -->
+            <li><a href="/gems/operation/2.0/policy.html">Policy</a></li>
+            <li><a href="/gems/operation/2.0/representer.html">Representer</a></li>
+            <!-- <li><a href="/gems/operation/2.0/pipetree.html">Pipetree</a></li> -->
+            <li><a href="/gems/operation/2.0/endpoint.html">Endpoint</a></li>
+            <li><a href="/gems/operation/1.1/index.html">
+                  <span class="sidebar-info">→ v1.1</span>
+                </a>
+            </li>
+        </ul>
     </li>
-    <li><a href="/gems/operation/2.0/api.html">API</a></li>
-    <li><a href="/gems/operation/2.0/contract.html">Contract</a></li>
-    <!-- <li><a href="/gems/operation/2.0/representer.html">Representer</a></li> -->
-    <li><a href="/gems/operation/2.0/policy.html">Policy</a></li>
-    <li><a href="/gems/operation/2.0/representer.html">Representer</a></li>
-<!--     <li><a href="/gems/operation/2.0/pipetree.html">Pipetree</a></li>
- -->
-    <li><a href="/gems/operation/2.0/endpoint.html">Endpoint</a></li>
-    <li><a href="/gems/operation/1.1/index.html">
-          <span class="sidebar-info">→ v1.1</span>
-        </a>
-    </li>
-    <li class="divider"></li>
 
-    <li class="heading">
-        <a href="/gems/trailblazer/index.html">
+    <li>
+        <a class="heading" href="#">
             <i class="fa fa-caret-square-o-right" aria-hidden="true"></i> TRAILBLAZER
         </a>
+        <ul class='menu vertical nested'>
+            <li><a href="/gems/trailblazer/index.html">Overview</a></li>
+            <li><a href="/gems/trailblazer/2.0/rails.html">Rails</a></li>
+            <li><a href="/gems/trailblazer/loader.html">Loader</a></li>
+        </ul>
     </li>
-    <li><a href="/gems/trailblazer/2.0/rails.html">Rails</a></li>
-    <li><a href="/gems/trailblazer/loader.html">Loader</a></li>
-    <li class="divider"></li>
 
-    <li class="heading">
-        <a href="/gems/cells">
+    <li>
+        <a class="heading" href="#">
             <i class="fa fa-caret-square-o-right" aria-hidden="true"></i> CELLS
         </a>
+        <ul class='menu vertical nested'>
+            <li><a href="/gems/cells">Overview</a></li>
+            <li><a href="/gems/cells/getting-started.html">Getting Started<span class="sidebar-info">NEW</span></li></a>
+            <li><a href="/gems/cells/api.html">API</a></li>
+            <li><a href="/gems/cells/trailblazer.html">Trailblazer::Cell</a></li>
+            <li><a href="/gems/cells/testing.html">Testing</a></li>
+            <li><a href="/gems/cells/render.html">Rendering</a></li>
+            <li><a href="/gems/cells/rails.html">Rails</a></li>
+            <li><a href="/gems/cells/templates.html">Templates</a></li>
+            <li><a href="/gems/cells/troubleshooting.html">Troubleshooting</a></li>
+        </ul>
     </li>
-    <li><a href="/gems/cells/getting-started.html">Getting Started<span class="sidebar-info">NEW</span></li></a>
-    <li><a href="/gems/cells/api.html">API</a></li>
-    <li><a href="/gems/cells/trailblazer.html">Trailblazer::Cell</a></li>
-    <li><a href="/gems/cells/testing.html">Testing</a></li>
-    <li><a href="/gems/cells/render.html">Rendering</a></li>
-    <li><a href="/gems/cells/rails.html">Rails</a></li>
-    <li><a href="/gems/cells/templates.html">Templates</a></li>
-    <li><a href="/gems/cells/troubleshooting.html">Troubleshooting</a></li>
-    <li class="divider"></li>
+    
 
-    <li class="heading">
-        <a href="/gems/reform">
+    <li>
+        <a class="heading" href="#">
             <i class="fa fa-caret-square-o-right" aria-hidden="true"></i> REFORM
         </a>
+        <ul class='menu vertical nested'>
+            <li><a href="/gems/reform">Overview</a></li>
+            <li><a href="/gems/reform/api.html">API</a></li>
+            <li><a href="/gems/reform/options.html">Options</a></li>
+            <li><a href="/gems/reform/data-types.html">Data Types</a></li>
+            <li><a href="/gems/reform/populator.html">Populator</a></li>
+            <li><a href="/gems/reform/prepopulator.html">Prepopulator</a></li>
+            <li><a href="/gems/reform/validation.html">Validation</a></li>
+            <li><a href="/gems/reform/rails.html">Rails</a></li>
+            <li><a href="/gems/reform/debugging.html">Debugging</a></li>
+            <li><a href="/gems/reform/upgrading-guide.html">Upgrading Guide</a></li>
+        </ul>
     </li>
-    <li><a href="/gems/reform/api.html">API</a></li>
-    <li><a href="/gems/reform/options.html">Options</a></li>
-    <li><a href="/gems/reform/data-types.html">Data Types</a></li>
-    <li><a href="/gems/reform/populator.html">Populator</a></li>
-    <li><a href="/gems/reform/prepopulator.html">Prepopulator</a></li>
-    <li><a href="/gems/reform/validation.html">Validation</a></li>
-    <li><a href="/gems/reform/rails.html">Rails</a></li>
-    <li><a href="/gems/reform/debugging.html">Debugging</a></li>
-    <li><a href="/gems/reform/upgrading-guide.html">Upgrading Guide</a></li>
-    <li class="divider"></li>
+    
 
-    <li class="heading">
-        <a href="/gems/representable">
+    <li>
+        <a class="heading" href="#">
             <i class="fa fa-caret-square-o-right" aria-hidden="true"></i> REPRESENTABLE
         </a>
+        <ul class='menu vertical nested'>
+            <li><a href="/gems/representable">Overview</a></li>
+            <li><a href="/gems/representable/getting-started.html">Getting Started</a></li>
+            <li><a href="/gems/representable/3.0/api.html">API</a></li>
+            <li><a href="/gems/representable/3.0/function-api.html">Function API</a></li>
+            <li><a href="/gems/representable/3.0/populator.html">Populator</a></li>
+            <!-- <li><a href="/gems/representable/architecture.html">Architecture</a></li> -->
+            <li><a href="/gems/representable/3.0/xml.html">XML</a></li>
+            <li><a href="/gems/representable/3.0/yaml.html">YAML</a></li>
+            <li><a href="/gems/representable/upgrading-guide.html">Upgrading Guide</a></li>
+        </ul>
     </li>
-    <li><a href="/gems/representable/getting-started.html">Getting Started</a></li>
-    <li><a href="/gems/representable/3.0/api.html">API</a></li>
-    <li><a href="/gems/representable/3.0/function-api.html">Function API</a></li>
-    <li><a href="/gems/representable/3.0/populator.html">Populator</a></li>
-    <!-- <li><a href="/gems/representable/architecture.html">Architecture</a></li> -->
-    <li><a href="/gems/representable/3.0/xml.html">XML</a></li>
-    <li><a href="/gems/representable/3.0/yaml.html">YAML</a></li>
-    <li><a href="/gems/representable/upgrading-guide.html">Upgrading Guide</a></li>
-    <li class="divider"></li>
+    
 
-    <li class="heading">
-        <a href="/gems/roar">
+    <li>
+        <a class="heading" href="#">
             <i class="fa fa-caret-square-o-right" aria-hidden="true"></i> ROAR
         </a>
+        <ul class='menu vertical nested'>
+            <li><a href="/gems/roar">Overview</a></li>
+            <li><a href="/gems/roar/jsonapi.html">JSON API</a></li>
+        </ul>
     </li>
-    <li><a href="/gems/roar/jsonapi.html">JSON API</a></li>
-    <li class="divider"></li>
+    
 
-    <li class="heading">
-        <a href="/gems/disposable">
+    <li>
+        <a class="heading" href="#">
             <i class="fa fa-caret-square-o-right" aria-hidden="true"></i> DISPOSABLE
         </a>
+        <ul class='menu vertical nested'>
+            <li><a href="/gems/disposable">Overview</a></li>
+            <li><a href="/gems/disposable/api.html">API</a></li>
+            <li><a href="/gems/disposable/default.html">Default</a></li>
+            <li><a href="/gems/disposable/callback.html">Callback</a></li>
+        </ul>
     </li>
-    <li><a href="/gems/disposable/api.html">API</a></li>
-    <li><a href="/gems/disposable/default.html">Default</a></li>
-    <li><a href="/gems/disposable/callback.html">Callback</a></li>
-    <li class="divider"></li>
+    
 
-    <li class="heading">
-        <a href="/guides">
+    <li>
+        <a class="heading" href="#">
             <i class="fa fa-caret-square-o-right" aria-hidden="true"></i> GUIDES
         </a>
+        <ul class='menu vertical nested'>
+            <li><a href="/guides">Overview</a></li>
+            <li><a href="/guides/trailblazer/2.0/01-operation-basics.html">01 - Operation Basics</a></li>
+            <li><a href="/guides/trailblazer/2.0/02-trailblazer-basics.html">02 - Trailblazer Basics</a></li>
+        </ul>
     </li>
-    <li><a href="/guides/trailblazer/2.0/01-operation-basics.html">01 - Operation Basics</a></li>
-    <li><a href="/guides/trailblazer/2.0/02-trailblazer-basics.html">02 - Trailblazer Basics</a></li>
 </ul>

--- a/_plugins/toctoctoc.rb
+++ b/_plugins/toctoctoc.rb
@@ -37,7 +37,16 @@ module Jekyll
       path = page.path.sub("/index.md", "")
       path = path.sub(".md", ".html")
       path = "/#{path}"
-      a = doc.css(".side-nav>li>a[href='#{path}']").first and a[:class] = "active"
+      current_a = doc.css(".side-nav li a[href='#{path}']").first
+      if current_a
+        # Set active class for this <a>, and also its corresponding '.link-group' parent
+        current_a[:class] += " is-active"
+        current_li = current_a.parent
+        nested_ul = current_li.parent
+        if nested_ul[:class] =~ "nested"
+          nested_ul[:class] += " is-active"
+        end
+      end
 
 
 # add magellan target

--- a/scss/_settings.scss
+++ b/scss/_settings.scss
@@ -234,7 +234,7 @@ $accordion-content-padding: 1rem;
 // 8. Accordion Menu
 // -----------------
 
-$accordionmenu-arrows: true;
+$accordionmenu-arrows: false;
 $accordionmenu-arrow-color: $primary-color;
 
 // 9. Badge

--- a/scss/components/_sidebar.scss
+++ b/scss/components/_sidebar.scss
@@ -23,11 +23,16 @@
     }
 
   }
-  li.heading {
+  li a.heading {
     font-weight:bold;
   }
   li.divider {
     border-top: 1px solid scale-color($nav-link-color, $lightness: 90%);
+  }
+
+  ul.link-group{
+    list-style-type: none;
+    margin: 0;
   }
 
   .page-toc-heading {


### PR DESCRIPTION
- Separates nav 'sub-links' into `.link-groups`
- Updates TOC generator to add `.active` class to the link-group that is `.active`, which effectively hides the non-active `.link-groups`

Unfortunately, I can't get this repo running locally, so I can't really test it. 😢  I just wanted to get it out there in case anyone who can test it out can do so.

Here is what I *imagine* it to look like:

![screen shot 2017-02-14 at 4 46 32 pm](https://cloud.githubusercontent.com/assets/908365/22950896/31d14c96-f2d5-11e6-8675-32b24ae028f2.png)


Closes #75 