### PR TITLE
Fix typo ( SongsRepresentable )

### DIFF
--- a/gems/representable/3.0/api.md
+++ b/gems/representable/3.0/api.md
@@ -684,7 +684,7 @@ Rendering a collection of objects comes for free, using `for_collection`.
 For parsing, you need to provide the class for the nested items. This happens via `collection_representer` in the representer class.
 
 ```ruby
-class SongsRepresenter < Representable::Decorator
+class SongRepresenter < Representable::Decorator
   include Representable::JSON
   property :title
 


### PR DESCRIPTION
Just fix a small typo. For parsing without dedicated array representable, you need to change SongRepresentable, not SongsRepresentable. Duplicate https://github.com/trailblazer/trailblazer.github.io/pull/93