### PR TITLE
Fixed broken link to dry-rb website

### DIFF
--- a/guides/trailblazer/2.0/02-trailblazer-basics.md
+++ b/guides/trailblazer/2.0/02-trailblazer-basics.md
@@ -71,7 +71,7 @@ The `trailblazer` gem brings the operation, the Reform gem for contracts, and so
 
 We already discussed `rspec`'s role. Mentioning the `activerecord` gem is important, since we need a persistence layer. Please be advised, though, that Trailblazer is database-agnostic: you can use ROM, `Hanami::Model`, Sequel, or whatever else you feel like.
 
-For validations, we refrain from using `ActiveModel::Validation` in this example and use the excellent [dry-validation gem](dry-rb.org/gems/dry-validation/). Reform allows using `dry-v` out-of-the-box. In case you want to/have to use ActiveModel's validations, no problem, Reform does that, too.
+For validations, we refrain from using `ActiveModel::Validation` in this example and use the excellent [dry-validation gem](http://dry-rb.org/gems/dry-validation/). Reform allows using `dry-v` out-of-the-box. In case you want to/have to use ActiveModel's validations, no problem, Reform does that, too.
 
 ## Model
 


### PR DESCRIPTION
The link was incorrectly pointing to `http://trailblazer.to/guides/trailblazer/2.0/dry-rb.org/gems/dry-validation/`