### PR TITLE
Fix markdown link to Bootstrap docs

### DIFF
--- a/gems/formular/index.md
+++ b/gems/formular/index.md
@@ -8,7 +8,7 @@ gems:
 
 WORK IN PROGRESS.
 
-Checkout [bootstrap.html](the Bootstrap docs).
+Checkout [the Bootstrap docs](bootstrap.html).
 
 ## Bootstrap 3
 


### PR DESCRIPTION
Fixes link on Formular gem docs to the bootstrap docs page.