### PR TITLE
Fix in Cells Rails i18n include

### DIFF
--- a/gems/cells/rails.md
+++ b/gems/cells/rails.md
@@ -206,7 +206,7 @@ You can use the `#t` helper.
 
 	class Admin::Comment::Cell < Cell::Concept
 	  include ActionView::Helpers::TranslationHelper
-	  include Cell::Translation
+	  include ::Cell::Translation
 
 	  def show
 	    t(".greeting")


### PR DESCRIPTION
In my rails environment with trailblazer I had to use `include ::Cell::Translation`. Otherwise there was an error given because it was tried to find `Translation` inside of my applications own `Cell` namespace.