### PR TITLE
Typo Fix on Home Page

### DIFF
--- a/index.md
+++ b/index.md
@@ -78,7 +78,7 @@ The Trailblazer gems work with any Ruby framework. We provide glue code for Rail
   Legacy-ready
 </h4>
 
-You can start using Trailblazer in existing, massive applications today. Refactorings can be applied step-wise, legacy code can be minimized as you go. Remember: Rome wasn't build in one day, either.
+You can start using Trailblazer in existing, massive applications today. Refactorings can be applied step-wise, legacy code can be minimized as you go. Remember: Rome wasn't built in one day, either.
 
 ~~~4
 <h4>


### PR DESCRIPTION
I believe the text under 'Legacy Ready' reads better with 'Rome wasn't buil*t* in one day, either', as opposed to 'Rome wasn't buil*d* in one day, either', to match the most common (at least American) English usage. 

If 'build' was intentional, please accept my sincere apologies and reject.