### PR TITLE
Deletion populator and multiple new records

### DIFF
--- a/gems/reform/populator.md
+++ b/gems/reform/populator.md
@@ -269,7 +269,7 @@ You can implement your own deletion.
     collection :songs,
       populator: ->(fragment:, **) {
         # find out if incoming song is already added.
-        item = songs.find { |song| song.id.to_s == fragment["id"].to_s }
+        item = songs.find { |song| song.id.present? && song.id.to_s == fragment["id"].to_s }
 
         if fragment["delete"] == "1"
           songs.delete(item)


### PR DESCRIPTION
I found out that using the default example for deletion Populator does not allow to have multiple new items added to collection.
In this case all new fragments do not have `id`. So find matcher will return the wrong item since `song.id.to_s == fragment["id"].to_s` (nil == nil) will always be true from 2nd run.

I suggest we additonally check for id presence.